### PR TITLE
fix: update SQL queries to fetch data based on the latest date instea…

### DIFF
--- a/backend/internal/store/stocks.go
+++ b/backend/internal/store/stocks.go
@@ -28,7 +28,7 @@ type StockStore struct {
 func (s *StockStore) Get(ctx context.Context) ([]*Stock, error) {
 	query := `SELECT id, date, trading_code, ltp, high, low, openp, closep, ycp, trade, value, volume
               FROM stock_history
-              WHERE date = CURRENT_DATE
+              WHERE date = (SELECT MAX(date) FROM stock_history);
 	`
 	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
@@ -61,6 +61,7 @@ func (s *StockStore) Get(ctx context.Context) ([]*Stock, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+
 	return stocks, nil
 }
 
@@ -106,7 +107,7 @@ func (s *StockStore) GetByID(ctx context.Context, tradingCode string, start time
 func (s *StockStore) GetCurrentByID(ctx context.Context, tradingCode string) (*Stock, error) {
 	query := `SELECT id, date, trading_code, ltp, high, low, openp, closep, ycp, trade, value, volume
               FROM stock_history
-              WHERE trading_code = $1 AND date = CURRENT_DATE
+              WHERE trading_code = $1 AND date = (SELECT MAX(date) FROM stock_history)
             `
 	stock := &Stock{}
 	err := s.db.QueryRowContext(ctx, query, tradingCode).Scan(


### PR DESCRIPTION
This pull request updates the logic for retrieving stock data to ensure that queries always return results for the most recent available date, rather than only for the current date. This change improves the reliability of data access, especially when the database does not have entries for the current date.

**Stock retrieval logic improvements:**

* Updated the query in `StockStore.Get` to select stock data for the latest date in `stock_history` instead of only for the current date.
* Modified the query in `StockStore.GetCurrentByID` to fetch the latest available entry for a given `trading_code`, using the maximum date in `stock_history`.

**Minor code cleanup:**

* Added a blank line before the return statement in `StockStore.Get` for improved readability.…d of current date