### PR TITLE
feat: implement forgot password and reset password functionality with…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 up:
-	docker compose --env-file secrets.env up 
+	docker compose --env-file secrets.env up
 build:
 	docker compose --env-file secrets.env up --build

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -52,7 +52,7 @@ func main() {
 		env:          env.GetString("ENVIRONMENT", "DEVELOPMENT"),
 		addr:         env.GetString("ADDR", ":8080"),
 		apiUrl:       env.GetString("API_URL", "localhost:8080"),
-		frontendURL:  env.GetString("FRONT_END_URL_PROD", "http://localhost:5173"),
+		frontendURL:  env.GetString("FRONT_END_URL_PROD", "http://localhost:3000"),
 		predictorURL: env.GetString("PREDICTOR_URL", "http://predictor:8000"),
 		smtp:         smtp,
 		limiter:      limiter,

--- a/backend/cmd/api/predictions.go
+++ b/backend/cmd/api/predictions.go
@@ -59,7 +59,6 @@ func (app *application) getPredictions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.logger.Info("PREDICTOR URL", app.cfg.predictorURL)
 	resp, err := http.Post(fmt.Sprintf("%s/api/predict", app.cfg.predictorURL), "application/json", bytes.NewBuffer(requestBody))
 	if err != nil {
 		app.serverErrorResponse(w, r, err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - bd-stock-api
     environment:
       DB_ADDR: "postgres://stock_cast:${POSTGRES_PASSWORD}@postgres:5432/stock_cast?sslmode=disable"
-      PREDICTOR_URL: "http://predictor:8000"
+      PREDICTOR_URL: ${PREDICTOR_URL}
       JWT_SECRET: ${JWT_SECRET}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}

--- a/frontend/components/forgot-password-form.tsx
+++ b/frontend/components/forgot-password-form.tsx
@@ -1,40 +1,81 @@
-import type React from "react"
-import { cn } from "@/lib/utils"
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card"
+import { cn } from "@/lib/utils"
+import React from "react"
+import { forgotPasswordSchema, forgotPasswordType } from "@/schema/users"
+import { useMutation } from "@tanstack/react-query"
+import { AuthAPI } from "@/lib/api/auth"
+import { toast } from "sonner"
+import { useRouter } from "next/navigation"
+
 
 export function ForgotPasswordForm({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card>
-        <CardHeader className="text-center space-y-2">
-          <CardTitle className="text-2xl font-bold">Reset Your Password</CardTitle>
-          <CardDescription>Enter your email address and we&apos;ll send you a link to reset your password</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form>
-            <div className="flex flex-col gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="email" className="font-bold">Email</Label>
-                <Input id="email" type="email" placeholder="trader@example.com" required className="placeholder:text-foreground" />
-              </div>
-              <div className="flex flex-col gap-3">
-                <Button type="submit" className="w-full">
-                  Send Reset Link
-                </Button>
-              </div>
-            </div>
-            <div className="mt-6 text-center text-sm text-muted-foreground">
-              Remember your password?{" "}
-              <a href="/login" className="text-primary hover:underline">
-                Back to login
-              </a>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
-  )
+    const router = useRouter();
+    const form = useForm<forgotPasswordType>({
+        resolver: zodResolver(forgotPasswordSchema),
+        defaultValues: {
+            email: "",
+        },
+    })
+
+    const { isPending, mutate } = useMutation<void, Error, forgotPasswordType>({
+        mutationFn: AuthAPI.forgotPassword,
+        onSuccess: () => {
+            toast.success("Password reset link sent!")
+            router.push("/login")
+        },
+        onError: (error) => {
+            toast.error(error.message || "An error occurred")
+        }
+    })
+
+    function onSubmit(values: forgotPasswordType) {
+        mutate(values)
+    }
+
+    return (
+        <div className={cn("flex flex-col gap-6", className)} {...props}>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Forgot your password?</CardTitle>
+                    <CardDescription>Enter your email address and we will send you a link to reset your password.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                            <FormField
+                                control={form.control}
+                                name="email"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Email</FormLabel>
+                                        <FormControl>
+                                            <Input placeholder="m@example.com" {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <Button type="submit" className="w-full" disabled={isPending}>
+                                {isPending ? "Loading..." : "Send reset link"}
+                            </Button>
+                        </form>
+                    </Form>
+                </CardContent>
+            </Card>
+        </div>
+    )
 }

--- a/frontend/components/reset-password-form.tsx
+++ b/frontend/components/reset-password-form.tsx
@@ -1,48 +1,100 @@
-import type React from "react"
-import { cn } from "@/lib/utils"
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card"
+import { cn } from "@/lib/utils"
+import React from "react"
+import { updatePasswordSchema, updatePasswordType } from "@/schema/users"
+import { useMutation } from "@tanstack/react-query"
+import { AuthAPI } from "@/lib/api/auth"
+import { toast } from "sonner"
+import { useRouter } from "next/navigation"
 
 export function ResetPasswordForm({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card>
-        <CardHeader className="text-center space-y-2">
-          <CardTitle className="text-2xl font-bold">Reset Your Password</CardTitle>
-          <CardDescription>Enter the token from your email and create a new password</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form>
-            <div className="flex flex-col gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="token" className="font-bold">Reset Token</Label>
-                <Input id="token" type="text" placeholder="Enter the token from your email" required className="placeholder:text-foreground" />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="password" className="font-bold">New Password</Label>
-                <Input id="password" type="password" placeholder="Enter your new password" required className="placeholder:text-foreground" />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="confirmPassword" className="font-bold">Confirm New Password</Label>
-                <Input id="confirmPassword" type="password" placeholder="Confirm your new password" required className="placeholder:text-foreground" />
-              </div>
-              <div className="flex flex-col gap-3">
-                <Button type="submit" className="w-full">
-                  Reset Password
-                </Button>
-              </div>
-            </div>
-            <div className="mt-6 text-center text-sm text-muted-foreground">
-              Remember your password?{" "}
-              <a href="/login" className="text-primary hover:underline">
-                Back to login
-              </a>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
-  )
+    const router = useRouter();
+    const form = useForm<updatePasswordType>({
+        resolver: zodResolver(updatePasswordSchema),
+        defaultValues: {
+            password: "",
+            token: "",
+        },
+    })
+
+    const { isPending, mutate } = useMutation<unknown, Error, updatePasswordType>({
+        mutationFn: AuthAPI.updatePassword,
+        onSuccess: () => {
+            toast.success("Password updated successfully!")
+            router.push("/login")
+        },
+        onError: (error) => {
+            toast.error(error.message || "An error occurred")
+        }
+    })
+
+    function onSubmit(values: updatePasswordType) {
+        mutate(values)
+    }
+
+    return (
+        <div className={cn("flex flex-col gap-6", className)} {...props}>
+            <Card>
+                <CardHeader className="text-center space-y-2">
+                    <CardTitle className="text-2xl font-bold">Reset Your Password</CardTitle>
+                    <CardDescription>Enter the token from your email and create a new password</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                            <FormField
+                                control={form.control}
+                                name="token"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Reset Token</FormLabel>
+                                        <FormControl>
+                                            <Input placeholder="Enter the token from your email" {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="password"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>New Password</FormLabel>
+                                        <FormControl>
+                                            <Input type="password" placeholder="Enter your new password" {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <Button type="submit" className="w-full" disabled={isPending}>
+                                {isPending ? "Loading..." : "Reset Password"}
+                            </Button>
+                        </form>
+                    </Form>
+                    <div className="mt-6 text-center text-sm text-muted-foreground">
+                        Remember your password?{" "}
+                        <a href="/login" className="text-primary hover:underline">
+                            Back to login
+                        </a>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    )
 }

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { loginSchemaType, registerSchemaType } from "@/schema/users";
+import { forgotPasswordType, loginSchemaType, registerSchemaType, updatePasswordType } from "@/schema/users";
 import { postAPI } from "./utils";
 import { EnvelopeLoginUser, EnvelopeRegisterUser } from "@/types/api";
 
@@ -12,5 +12,13 @@ export class AuthAPI {
 
     static async login(loginPayload: loginSchemaType): Promise<EnvelopeLoginUser> {
         return postAPI(`${USERS_PATH}/login`, loginPayload)
+    }
+
+    static async forgotPassword(payload: forgotPasswordType): Promise<void> {
+        return postAPI(`${USERS_PATH}/forgot-password`, payload)
+    }
+
+    static async updatePassword(payload: updatePasswordType): Promise<void> {
+        return postAPI(`${USERS_PATH}/update-password`, payload)
     }
 }

--- a/frontend/schema/users.ts
+++ b/frontend/schema/users.ts
@@ -11,12 +11,23 @@ export const registerSchema = z.object({
         message: "Password must be at least 8 characters.",
     }),
 })
-
 export type registerSchemaType = z.infer<typeof registerSchema>
 
 export const loginSchema = z.object({
     email: z.string().email(),
     password: z.string().nonempty(),
 })
-
 export type loginSchemaType = z.infer<typeof loginSchema>
+
+export const forgotPasswordSchema = z.object({
+    email: z.string().email()
+})
+export type forgotPasswordType = z.infer<typeof forgotPasswordSchema>
+
+export const updatePasswordSchema = z.object({
+    password: z.string().min(8, {
+        message: "Password must be at least 8 characters.",
+    }),
+    token: z.string()
+})
+export type updatePasswordType = z.infer<typeof updatePasswordSchema>


### PR DESCRIPTION
This pull request introduces significant improvements to the password reset flow on the frontend, adds new API methods to support these features, and makes configuration changes to the backend and Docker setup for better flexibility and consistency.

**Frontend: Password Reset Flow Improvements**
- The `ForgotPasswordForm` and `ResetPasswordForm` components are refactored to use `react-hook-form` with Zod validation, providing better form handling, validation, and user feedback. Both forms now leverage `react-query` for API calls and display toast notifications for success or error states. [[1]](diffhunk://#diff-f3e9c284c3b909853b871df0b62bc73521796c1e24b9e730e4c065029c521c01L1-R76) [[2]](diffhunk://#diff-3150233852ab04b05599a118517008374edb851d5841907866df74bbaf6c904cL1-R48) [[3]](diffhunk://#diff-3150233852ab04b05599a118517008374edb851d5841907866df74bbaf6c904cL17-L43)
- New Zod schemas and types for password reset (`forgotPasswordSchema`, `updatePasswordSchema`) are added to `frontend/schema/users.ts` to enforce validation on the frontend.
- The `AuthAPI` class is extended with `forgotPassword` and `updatePassword` methods for interacting with the backend password reset endpoints. [[1]](diffhunk://#diff-694dd0991916d537129c6efa1f6e4c3deb465876a22dabbb1a340b0b316f37afL1-R1) [[2]](diffhunk://#diff-694dd0991916d537129c6efa1f6e4c3deb465876a22dabbb1a340b0b316f37afR16-R23)

**Backend and Deployment Configuration**
- The default frontend URL in the backend configuration is updated from `http://localhost:5173` to `http://localhost:3000` to match the likely Next.js development server.
- The `PREDICTOR_URL` environment variable in `docker-compose.yml` is now passed through from the environment, improving flexibility for deployment.
- An unnecessary log statement for the predictor URL is removed from the backend API handler for cleaner logs.… form validation