### PR TITLE
Include previous trading days in predictions

### DIFF
--- a/frontend/components/stock-prediction/stock-prediction-chart.tsx
+++ b/frontend/components/stock-prediction/stock-prediction-chart.tsx
@@ -1,125 +1,120 @@
 import {
-    CartesianGrid,
-    Line,
-    LineChart,
-    ReferenceLine,
-    ResponsiveContainer,
-    Tooltip,
-    XAxis,
-    YAxis,
+	CartesianGrid,
+	Line,
+	LineChart,
+	ReferenceLine,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
 } from "recharts";
 import { formatCurrency } from "@/lib/utils/format";
 
 interface StockPredictionChartProps {
-    chartData: { date: string; price: number; day: number }[];
-    currentPrice: number;
+	chartData: { date: string; history?: number; prediction?: number }[];
+	currentPrice: number;
 }
 
-export function StockPredictionChart({ chartData, currentPrice }: StockPredictionChartProps) {
-    return (
-        <div className="space-y-4">
-            <h4 className="font-medium">Price Trajectory</h4>
-            <div className="h-64">
-                <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                        data={chartData}
-                        margin={{
-                            top: 5,
-                            right: 30,
-                            left: 20,
-                            bottom: 5,
-                        }}
-                    >
-                        <CartesianGrid
-                            strokeDasharray="3 3"
-                            className="stroke-muted"
-                        />
-                        <XAxis
-                            dataKey="date"
-                            className="text-xs fill-muted-foreground"
-                            tickFormatter={(value) => {
-                                if (typeof value === "string") {
-                                    return new Date(
-                                        value.replace(
-                                            /-/g,
-                                            "/",
-                                        ),
-                                    ).toLocaleDateString(
-                                        "en-US",
-                                        {
-                                            month: "short",
-                                            day: "numeric",
-                                        },
-                                    );
-                                }
-                                return value;
-                            }}
-                        />
-                        <YAxis
-                            className="text-xs fill-muted-foreground"
-                            tickFormatter={(value) =>
-                                formatCurrency(value)
-                            }
-                        />
-                        <Tooltip
-                            content={({ active, payload, label }) => {
-                                if (active && payload && payload.length) {
-                                    return (
-                                        <div className="bg-background border rounded-lg p-3 shadow-lg">
-                                            <p className="text-sm font-medium">
-                                                {typeof label === "string"
-                                                    ? new Date(
-                                                          label.replace(
-                                                              /-/g,
-                                                              "/",
-                                                          ),
-                                                      ).toLocaleDateString(
-                                                          "en-US",
-                                                          {
-                                                              weekday: "short",
-                                                              month: "short",
-                                                              day: "numeric",
-                                                          },
-                                                      )
-                                                    : label}
-                                            </p>
-                                            <p className="text-sm text-primary">
-                                                Price:{" "}
-                                                {formatCurrency(
-                                                    payload[0].value as number,
-                                                )}
-                                            </p>
-                                        </div>
-                                    );
-                                }
-                                return null;
-                            }}
-                        />
-                        <Line
-                            type="monotone"
-                            dataKey="price"
-                            stroke="hsl(var(--primary))"
-                            strokeWidth={2}
-                            dot={{
-                                fill: "hsl(var(--primary))",
-                                strokeWidth: 2,
-                                r: 4,
-                            }}
-                            activeDot={{
-                                r: 6,
-                                stroke: "hsl(var(--primary))",
-                                strokeWidth: 2,
-                            }}
-                        />
-                        <ReferenceLine
-                            y={currentPrice}
-                            label="Current Price"
-                            stroke="red"
-                            strokeDasharray="3 3"
-                        />
-                    </LineChart>
-                </ResponsiveContainer>
-            </div>
-        </div>
-    );
+export function StockPredictionChart({
+	chartData,
+	currentPrice,
+}: StockPredictionChartProps) {
+
+	return (
+		<div className="space-y-4">
+			<h4 className="font-medium">Price Trajectory</h4>
+			<div className="h-64">
+				<ResponsiveContainer width="100%" height="100%">
+					<LineChart
+						data={chartData}
+						margin={{
+							top: 5,
+							right: 30,
+							left: 20,
+							bottom: 5,
+						}}
+					>
+						<CartesianGrid
+							strokeDasharray="3 3"
+							className="stroke-muted"
+						/>
+						<XAxis
+							dataKey="date"
+							className="text-xs fill-muted-foreground"
+							tickFormatter={(value) => {
+								if (typeof value === "string") {
+									return new Date(
+										value.replace(/-/g, "/"),
+									).toLocaleDateString("en-US", {
+										month: "short",
+										day: "numeric",
+									});
+								}
+								return value;
+							}}
+						/>
+						<YAxis
+							className="text-xs fill-muted-foreground"
+							tickFormatter={(value) => formatCurrency(value)}
+						/>
+						<Tooltip
+							content={({ active, payload, label }) => {
+								if (active && payload && payload.length) {
+									return (
+										<div className="bg-background border rounded-lg p-3 shadow-lg">
+											<p className="text-sm font-medium">
+												{typeof label === "string"
+													? new Date(
+															label.replace(
+																/-/g,
+																"/",
+															),
+														).toLocaleDateString(
+															"en-US",
+															{
+																weekday:
+																	"short",
+																month: "short",
+																day: "numeric",
+															},
+														)
+													: label}
+											</p>
+											<p className="text-sm text-primary">
+												Price:{" "}
+												{formatCurrency(
+													payload[0].value as number,
+												)}
+											</p>
+										</div>
+									);
+								}
+								return null;
+							}}
+						/>
+						<Line
+							type="monotone"
+							dataKey="history"
+							stroke="#8884d8"
+							strokeWidth={4}
+							dot={false}
+						/>
+						<Line
+							type="monotone"
+							dataKey="prediction"
+							stroke="#82ca9d"
+							strokeWidth={4}
+							dot={false}
+						/>{" "}
+						<ReferenceLine
+							y={currentPrice}
+							label="Current Price"
+							stroke="red"
+							strokeDasharray="3 3"
+						/>
+					</LineChart>
+				</ResponsiveContainer>
+			</div>
+		</div>
+	);
 }

--- a/frontend/components/stock-prediction/stock-prediction-summary.tsx
+++ b/frontend/components/stock-prediction/stock-prediction-summary.tsx
@@ -3,92 +3,85 @@ import { TrendingUp, TrendingDown } from "lucide-react";
 import type { PredictionPeriod } from "@/types/prediction";
 
 interface StockPredictionSummaryProps {
-    currentPrice: number;
-    finalPrice: number;
-    selectedPeriod: PredictionPeriod;
-    priceChange: {
-        amount: number;
-        percentage: number;
-    };
+	currentPrice: number;
+	finalPrice: number;
+	selectedPeriod: PredictionPeriod;
+	priceChange: {
+		amount: number;
+		percentage: number;
+	};
 }
-
-export function StockPredictionSummary({ currentPrice, finalPrice, selectedPeriod, priceChange }: StockPredictionSummaryProps) {
-    const isPositive = priceChange.amount >= 0;
-    return (
-        <>
-            <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                    <p className="text-sm text-muted-foreground">
-                        Current Price
-                    </p>
-                    <p className="text-2xl font-bold">
-                        {formatCurrency(currentPrice)}
-                    </p>
-                </div>
-                <div className="space-y-2">
-                    <p className="text-sm text-muted-foreground">
-                        Predicted ({selectedPeriod} day
-                        {selectedPeriod > 1 ? "s" : ""})
-                    </p>
-                    <div className="flex items-center gap-2">
-                        <p className="text-2xl font-bold">
-                            {formatCurrency(finalPrice)}
-                        </p>
-                        <div
-                            className={`flex items-center gap-1 ${
-                                isPositive
-                                    ? "text-success"
-                                    : "text-destructive"
-                            }`}
-                        >
-                            {isPositive ? (
-                                <TrendingUp className="h-4 w-4" />
-                            ) : (
-                                <TrendingDown className="h-4 w-4" />
-                            )}
-                            <span className="text-sm font-medium">
-                                {formatPercentage(
-                                    Math.abs(
-                                        priceChange.percentage,
-                                    ),
-                                )}
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div
-                className={`p-4 rounded-lg border ${
-                    isPositive
-                        ? "bg-success/5 border-success/20"
-                        : "bg-destructive/5 border-destructive/20"
-                }`}
-            >
-                <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">
-                        Expected Change
-                    </span>
-                    <div
-                        className={`flex items-center gap-2 ${
-                            isPositive
-                                ? "text-success"
-                                : "text-destructive"
-                        }`}
-                    >
-                        <span className="font-bold">
-                            {isPositive ? "+" : ""}
-                            {formatCurrency(priceChange.amount)}
-                        </span>
-                        <span className="text-sm">
-                            ({isPositive ? "+" : ""}
-                            {formatPercentage(
-                                priceChange.percentage,
-                            )}
-                            )
-                        </span>
-                    </div>
-                </div>
-            </div>
-        </>
-    );
+export function StockPredictionSummary({
+	currentPrice,
+	finalPrice,
+	selectedPeriod,
+	priceChange,
+}: StockPredictionSummaryProps) {
+	const isPositive = priceChange.amount >= 0;
+	return (
+		<>
+			<div className="grid grid-cols-2 gap-4">
+				<div className="space-y-2">
+					<p className="text-sm text-muted-foreground">
+						Current Price
+					</p>
+					<p className="text-2xl font-bold">
+						{formatCurrency(currentPrice)}
+					</p>
+				</div>
+				<div className="space-y-2">
+					<p className="text-sm text-muted-foreground">
+						Predicted ({selectedPeriod} day
+						{selectedPeriod > 1 ? "s" : ""})
+					</p>
+					<div className="flex items-center gap-2">
+						<p className="text-2xl font-bold">
+							{formatCurrency(finalPrice)}
+						</p>
+						<div
+							className={`flex items-center gap-1 ${
+								isPositive ? "text-success" : "text-destructive"
+							}`}
+						>
+							{isPositive ? (
+								<TrendingUp className="h-4 w-4" />
+							) : (
+								<TrendingDown className="h-4 w-4" />
+							)}
+							<span className="text-sm font-medium">
+								{formatPercentage(
+									Math.abs(priceChange.percentage),
+								)}
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div
+				className={`p-4 rounded-lg border ${
+					isPositive
+						? "bg-success/5 border-success/20"
+						: "bg-destructive/5 border-destructive/20"
+				}`}
+			>
+				<div className="flex items-center justify-between">
+					<span className="text-sm font-medium">Expected Change</span>
+					<div
+						className={`flex items-center gap-2 ${
+							isPositive ? "text-success" : "text-destructive"
+						}`}
+					>
+						<span className="font-bold">
+							{isPositive ? "+" : ""}
+							{formatCurrency(priceChange.amount)}
+						</span>
+						<span className="text-sm">
+							({isPositive ? "+" : ""}
+							{formatPercentage(priceChange.percentage)})
+						</span>
+					</div>
+				</div>
+			</div>
+		</>
+	);
 }

--- a/frontend/components/stock-prediction/use-stock-prediction.ts
+++ b/frontend/components/stock-prediction/use-stock-prediction.ts
@@ -6,11 +6,14 @@ import type {
 	PredictionPeriod,
 	StockPredictionResponse,
 } from "@/types/prediction";
+import { getPredictionData } from "@/lib/stock";
+import { StockHistoryPoint } from "@/types/stock";
 
 export function useStockPrediction(tradingCode: string, currentPrice: number) {
 	const [nhead, setNhead] = useState<PredictionPeriod>(7);
 	const [allPredictions, setAllPredictions] =
 		useState<StockPredictionResponse | null>(null);
+	const [prevDaysStock, setPrevDaysStock] = useState<StockHistoryPoint[]>([]);
 
 	const [model, setModel] =
 		useState<PredictionModelType>("StockCast/seperate");
@@ -18,7 +21,8 @@ export function useStockPrediction(tradingCode: string, currentPrice: number) {
 	const predictionMutation = useMutation({
 		mutationFn: StockAPI.getStockPrediction,
 		onSuccess: (data) => {
-			setAllPredictions(data);
+			setAllPredictions(data.response);
+			setPrevDaysStock(data.prevDays);
 		},
 	});
 
@@ -56,23 +60,28 @@ export function useStockPrediction(tradingCode: string, currentPrice: number) {
 			: "Failed to fetch predictions"
 		: null;
 
-	const getPredictionData = () => {
-		if (!allPredictions) return null;
-		const key = `${nhead}_day`;
-		return allPredictions.predictions[key];
-	};
+	const predictionData = getPredictionData(nhead, allPredictions);
 
-	const predictionData = getPredictionData();
+	const chartData: { date: string; history?: number; prediction?: number }[] =
+		prevDaysStock.map((p) => ({
+			date: p.date.slice(0, 10),
+			history: p.closep,
+		}));
 
-	const chartData = predictionData
-		? predictionData.predicted_prices.map(
-				(price: number, index: number) => ({
-					date: predictionData.dates[index],
-					price: price,
-					day: index + 1,
-				}),
-			)
-		: [];
+	if (chartData.length > 0) {
+		const lastPoint = chartData[chartData.length - 1];
+		lastPoint.prediction = lastPoint.history;
+	}
+
+	if (predictionData) {
+		const predictionPoints = predictionData.predicted_prices.map(
+			(price, index) => ({
+				date: predictionData.dates[index],
+				prediction: price,
+			}),
+		);
+		chartData.push(...predictionPoints);
+	}
 
 	const priceChange = predictionData
 		? {

--- a/frontend/lib/api/stock.ts
+++ b/frontend/lib/api/stock.ts
@@ -4,11 +4,9 @@ import type {
 	EnvelopeStocks,
 	RealTimeResponse,
 } from "@/types/api";
-import {
-	PredictionRequest,
-	StockPredictionResponse,
-} from "@/types/prediction";
+import { PredictionRequest, StockPredictionResponse } from "@/types/prediction";
 import type { Stock, StockHistoryPoint } from "@/types/stock";
+import { getStartDateForTradingDays } from "@/lib/time";
 import { deleteAPI, fetchAPI, fetchRealTimeAPI, postAPI } from "./utils";
 import { favoriteStockType } from "@/schema/stocks";
 
@@ -49,14 +47,31 @@ export class StockAPI {
 		tradingCode,
 		nhead,
 		model,
-	}: PredictionRequest): Promise<StockPredictionResponse> {
+	}: PredictionRequest): Promise<{
+		prevDays: StockHistoryPoint[];
+		response: StockPredictionResponse;
+	}> {
 		const request: PredictionRequest = { tradingCode, nhead, model };
+
+		const endDate = new Date();
+		const startDate = getStartDateForTradingDays(endDate, nhead + 1);
+
+		const prevDays = await StockAPI.getStockHistory(
+			tradingCode,
+			startDate.toISOString().slice(0, 10),
+			endDate.toISOString().slice(0, 10),
+		);
+
+
 		const response = await postAPI<StockPredictionResponse>(
 			"/predict",
 			request,
 		);
 
-		return response;
+		return {
+			prevDays,
+			response,
+		};
 	}
 
 	static async createFavoriteStock(

--- a/frontend/lib/stock.ts
+++ b/frontend/lib/stock.ts
@@ -1,0 +1,35 @@
+import { PredictionPeriod, StockPredictionResponse } from "@/types/prediction";
+
+export const getPredictionData = (
+	nhead: PredictionPeriod,
+	allPredictions: StockPredictionResponse | null,
+) => {
+	if (!allPredictions) return null;
+	const key = `${nhead}_day`;
+	const data = allPredictions.predictions[key];
+	if (!data || data.dates.length === 0) return null;
+
+	const openMarketDates: string[] = [];
+	const currentDate = new Date(data.dates[0].replace(/-/g, "/"));
+
+	const formatDate = (date: Date) => {
+		const year = date.getFullYear();
+		const month = (date.getMonth() + 1).toString().padStart(2, "0");
+		const day = date.getDate().toString().padStart(2, "0");
+		return `${year}-${month}-${day}`;
+	};
+
+	while (openMarketDates.length < data.dates.length) {
+		const dayOfWeek = currentDate.getDay();
+		if (dayOfWeek !== 5 && dayOfWeek !== 6) {
+			// Not Friday or Saturday
+			openMarketDates.push(formatDate(currentDate));
+		}
+		currentDate.setDate(currentDate.getDate() + 1);
+	}
+
+	return {
+		...data,
+		dates: openMarketDates,
+	};
+};

--- a/frontend/lib/time.ts
+++ b/frontend/lib/time.ts
@@ -73,3 +73,27 @@ export const getMarketStatus = () => {
 
 	return { isLive: false, message: "Market Closed" };
 };
+
+export function getStartDateForTradingDays(
+	endDate: Date,
+	numberOfDays: number,
+): Date {
+	const isFridayOrSaturday = (date: Date) => {
+		const day = date.getDay();
+		return day === 5 || day === 6;
+	};
+
+	let tradingDaysCount = 0;
+	let tempDate = new Date(endDate);
+	const tradingDates: Date[] = [];
+
+	while (tradingDaysCount < numberOfDays) {
+		if (!isFridayOrSaturday(tempDate)) {
+			tradingDates.push(new Date(tempDate));
+			tradingDaysCount++;
+		}
+		tempDate.setDate(tempDate.getDate() - 1);
+	}
+
+	return tradingDates[tradingDates.length - 1];
+}

--- a/frontend/lib/utils/axios.ts
+++ b/frontend/lib/utils/axios.ts
@@ -6,6 +6,8 @@ const API_BASE_URL =
 		? "http://localhost:8080/v1"
 		: process.env.NEXT_PUBLIC_API_BASE_URL + "/v1";
 
+// const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL + "/v1";
+
 const axiosInstance = axios.create({
 	baseURL: API_BASE_URL,
 });
@@ -46,6 +48,9 @@ const REALTIME_API_BASE_URL =
 	process.env.NODE_ENV === "development"
 		? "http://localhost:4000/v1/dse"
 		: process.env.NEXT_PUBLIC_REALTIME_API_BASE_URL + "/v1/dse";
+
+// const REALTIME_API_BASE_URL =
+// 	process.env.NEXT_PUBLIC_REALTIME_API_BASE_URL + "/v1/dse";
 
 export const realtimeAxiosInstance = axios.create({
 	baseURL: REALTIME_API_BASE_URL,

--- a/frontend/types/stock.ts
+++ b/frontend/types/stock.ts
@@ -1,54 +1,54 @@
 export interface Stock {
-    id: number
-    date: string // ISO date string, e.g. "2025-08-18"
-    tradingCode: string
-    ltp: number // Last Traded Price
-    high: number
-    low: number
-    openp: number // Opening Price
-    closep: number // Closing Price
-    ycp: number // Yesterday's Closing Price
-    trade: number
-    value: number
-    volume: number
+	id: number;
+	date: string; // ISO date string, e.g. "2025-08-18"
+	tradingCode: string;
+	ltp: number; // Last Traded Price
+	high: number;
+	low: number;
+	openp: number; // Opening Price
+	closep: number; // Closing Price
+	ycp: number; // Yesterday's Closing Price
+	trade: number;
+	value: number;
+	volume: number;
 }
 
 export interface StockHistoryPoint {
-    date: string
-    open: number
-    high: number
-    low: number
-    close: number
-    volume: number
+	date: string;
+	open: number;
+	high: number;
+	low: number;
+	closep: number;
+	volume: number;
 }
 
 export interface StockHistory {
-    tradingCode: string
-    history: StockHistoryPoint[]
+	tradingCode: string;
+	history: StockHistoryPoint[];
 }
 
 export interface StockNotification {
-    id: string
-    type: "price_alert" | "volume_spike" | "news" | "earnings" | "dividend"
-    tradingCode: string
-    title: string
-    message: string
-    timestamp: string
-    isRead: boolean
-    priority: "low" | "medium" | "high"
-    data?: {
-        currentPrice?: number
-        targetPrice?: number
-        volumeIncrease?: number
-        newsUrl?: string
-    }
+	id: string;
+	type: "price_alert" | "volume_spike" | "news" | "earnings" | "dividend";
+	tradingCode: string;
+	title: string;
+	message: string;
+	timestamp: string;
+	isRead: boolean;
+	priority: "low" | "medium" | "high";
+	data?: {
+		currentPrice?: number;
+		targetPrice?: number;
+		volumeIncrease?: number;
+		newsUrl?: string;
+	};
 }
 
 export interface UserFavorite {
-    tradingCode: string
-    addedAt: string
-    alertPrice?: number
-    notes?: string
+	tradingCode: string;
+	addedAt: string;
+	alertPrice?: number;
+	notes?: string;
 }
 
-export type ChartTimeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y"
+export type ChartTimeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";


### PR DESCRIPTION
Return alongside the prediction response and use it to build a combined chart dataset with separate history and prediction lines. Add getStartDateForTradingDays and getPredictionData helpers, update API to return prevDays, and adjust types and utilities.
This pull request refactors and improves the stock prediction chart and summary components, enhances prediction data handling, and updates API logic to fetch historical stock data alongside predictions. The main changes focus on separating historical and predicted data for charting, ensuring correct market dates are used, and cleaning up type definitions for consistency.

**Stock Prediction Chart and Data Handling Improvements**
* Refactored `StockPredictionChart` to accept `chartData` with separate `history` and `prediction` fields, and render two distinct lines for historical prices and predicted prices. [[1]](diffhunk://#diff-9cba9ef4559f78786f59dad589c07fe5a18330bc426700f7f04c72bf3c8a4883L14-R22) [[2]](diffhunk://#diff-9cba9ef4559f78786f59dad589c07fe5a18330bc426700f7f04c72bf3c8a4883L100-R108)
* Updated prediction data construction in `use-stock-prediction.ts` to combine previous days' historical stock prices with prediction points, ensuring the chart shows a clear transition from history to prediction. [[1]](diffhunk://#diff-3a1cba65e19c2dbb34448f80b0da0e5b271ff2f06628e789a86805caef0e1b3dR9-R25) [[2]](diffhunk://#diff-3a1cba65e19c2dbb34448f80b0da0e5b271ff2f06628e789a86805caef0e1b3dL59-R84)
* Added `getPredictionData` utility in `lib/stock.ts` to properly generate market dates for predictions, skipping weekends and aligning with trading days.

**API and Data Fetching Enhancements**
* Modified `StockAPI.getStockPrediction` to also fetch previous trading days' stock history, returning both the prediction response and historical data for charting.
* Introduced `getStartDateForTradingDays` in `lib/time.ts` to accurately calculate the start date for a given number of trading days, skipping Fridays and Saturdays.

**Type and Formatting Cleanups**
* Updated `StockHistoryPoint` type to use `closep` for consistency, and standardized formatting and indentation across stock-related types.
* Minor formatting and code style improvements in summary and chart components for readability. [[1]](diffhunk://#diff-efd8e529234a9e3858d232cbea652d14ff5043b97d3175f3d3ddeaf2e19126e6L39-R43) [[2]](diffhunk://#diff-efd8e529234a9e3858d232cbea652d14ff5043b97d3175f3d3ddeaf2e19126e6L51-R53) [[3]](diffhunk://#diff-efd8e529234a9e3858d232cbea652d14ff5043b97d3175f3d3ddeaf2e19126e6L68-R71) [[4]](diffhunk://#diff-efd8e529234a9e3858d232cbea652d14ff5043b97d3175f3d3ddeaf2e19126e6L84-R80)

These changes improve the accuracy and clarity of stock prediction visualizations and ensure the codebase is easier to maintain and extend.